### PR TITLE
Do not execute arbitrary commands

### DIFF
--- a/lib/gviz/core.rb
+++ b/lib/gviz/core.rb
@@ -229,7 +229,7 @@ class Gviz
   # the image is also created.
   def save(path, type=nil)
     File.open("#{path}.dot", "w") { |f| f.puts self }
-    system "dot -T#{type} #{path}.dot -o #{path}.#{type}" if type
+    system "dot", "-T", type.to_s, "#{path}.dot", "-o", "#{path}.#{type}" if type
   end
   
   private


### PR DESCRIPTION
`Kernel.#system` in `Gviz#save` can execute arbitrary commands now.
So I made it with multiple arguments instead of a single string argument.

## Example
### script
```ruby
require 'gviz'
a = Gviz.new
a.save("foobar", ": pwd")
```

### result
#### before
```
Missing argument for -T flag
Usage: dot [-Vv?] [-(GNE)name=val] [-(KTlso)<val>] <dot files>
(additional options for neato)    [-x] [-n<v>]
(additional options for fdp)      [-L(gO)] [-L(nUCT)<val>]
(additional options for memtest)  [-m<v>]
(additional options for config)  [-cv]

 -V          - Print version and exit
 -v          - Enable verbose mode 
 -Gname=val  - Set graph attribute 'name' to 'val'
 -Nname=val  - Set node attribute 'name' to 'val'
 -Ename=val  - Set edge attribute 'name' to 'val'
 -Tv         - Set output format to 'v'
 -Kv         - Set layout engine to 'v' (overrides default based on command name)
 -lv         - Use external library 'v'
 -ofile      - Write output to 'file'
 -O          - Automatically generate an output filename based on the input filename with a .'format' appended. (Causes all -ofile options to be ignored.) 
 -P          - Internally generate a graph of the current plugins. 
 -q[l]       - Set level of message suppression (=1)
 -s[v]       - Scale input by 'v' (=72)
 -y          - Invert y coordinate in output

 -n[v]       - No layout mode 'v' (=1)
 -x          - Reduce graph

 -Lg         - Don't use grid
 -LO         - Use old attractive force
 -Ln<i>      - Set number of iterations to i
 -LU<i>      - Set unscaled factor to i
 -LC<v>      - Set overlap expansion factor to v
 -LT[*]<v>   - Set temperature (temperature factor) to v

 -m          - Memory test (Observe no growth with top. Kill when done.)
 -m[v]       - Memory test - v iterations.

 -c          - Configure plugins (Writes $prefix/lib/graphviz/config 
               with available plugin information.  Needs write privilege.)
 -?          - Print usage and exit
/tmp
sh: foobar.dot: command not found
/tmp
```

(`/tmp` is `pwd` command's result.)

#### after
```
Format: "; pwd;" not recognized. Use one of: bmp canon cgimage cmap cmapx cmapx_np dot eps exr fig gif gv icns ico imap imap_np ismap jp2 jpe jpeg jpg pct pdf pic pict plain plain-ext png pov ps ps2 psd sgi svg svgz tga tif tiff tk vml vmlz xdot xdot1.2 xdot1.4
```